### PR TITLE
Updated push.yml with correct multi-line syntax.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       run: msbuild BassClefStudio.UWP.sln -t:build -p:Configuration=Debug -p:Platform=x64 -m -restore
     - name: Nuget Pack
       run: |
-      nuget pack .\BassClefStudio.UWP.Core\BassClefStudio.UWP.Core.nuspec
-      nuget pack .\BassClefStudio.UWP.Navigation\BassClefStudio.UWP.Navigation.nuspec
+        nuget pack .\BassClefStudio.UWP.Core\BassClefStudio.UWP.Core.nuspec
+        nuget pack .\BassClefStudio.UWP.Navigation\BassClefStudio.UWP.Navigation.nuspec
     - name: Nuget Push
       run: nuget push "*.nupkg" -Source "GPR" -SkipDuplicate


### PR DESCRIPTION
push.yml had an error with the indentation in YAML (whoops!) which caused the workflow to fail. This is now fixed.